### PR TITLE
Update pyqt5 dependency for python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 language: python
-sudo: required
-dist: trusty
+os: linux
+dist: bionic
 
 python:
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 
 before_install:
   - pip3 install jsonpickle  setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
 before_install:
   - pip3 install --upgrade pip
   - pip3 install jsonpickle  setuptools
-  - pip3 install pytest 'pytest-cov==2.6.0'
+  - pip3 install 'pytest==3.10.1' 'pytest-cov==2.6.0'
   - pip3 install coveralls
   - pip3 install gitpython
   - python3 setup.py sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ services:
   - xvfb
 
 before_install:
+  - pip3 install --upgrade pip
   - pip3 install jsonpickle  setuptools
   - pip3 install pytest 'pytest-cov==2.6.0'
   - pip3 install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  
+services:
+  - xvfb
 
 before_install:
   - pip3 install jsonpickle  setuptools
@@ -22,7 +25,6 @@ install:
 
 before_script:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
   
 script:

--- a/setup.py
+++ b/setup.py
@@ -126,9 +126,9 @@ def get_install_requires():
                       'scipy', 'tabulate', 'mpldatacursor',
                       'xmltodict', 'jsonpickle', 
                       'tikzplotlib', 'Pillow'],
-    else: # requires pyqt < 5.12, due to a bug in early 5.12.x versions
+    else:
         install_requires=['cycler', 'matplotlib', 'numpy', 
-                      'py', 'pyparsing', 'pyqt5<5.11', 'pytest',
+                      'py', 'pyparsing', 'pyqt5', 'pytest',
                       'python-dateutil', 'pytz', 'six', 
                       'scipy', 'tabulate', 'mpldatacursor',
                       'xmltodict', 'jsonpickle', 


### PR DESCRIPTION
RDPlot can be built, but not installed/run with python 3.8:

- "requires pyqt < 5.12, due to a bug in early 5.12.x versions" https://github.com/IENT/RDPlot/blob/75ef5f241464f702b23f6d0fbe6e54b198268032/setup.py#L129
- actually pulls `'pyqt5<5.11'` https://github.com/IENT/RDPlot/blob/75ef5f241464f702b23f6d0fbe6e54b198268032/setup.py#L131
- sip<4.20 is required by pyqt5<5.11 but not available anymore since python 3.8
- since pyqt5==5.11, [sip is included in pyqt5 as "private copy"](https://riverbankcomputing.com/static/Docs/PyQt5/incompatibilities.html#pyqt-v5-11)

```
$ python -V
Python 3.7.6

$ pip install sip==
Collecting sip==
  ERROR: Could not find a version that satisfies the requirement sip== (from versions: 4.19.7, 4.19.8, 5.0.0, 5.0.1, 5.1.0, 5.1.1)
```

```
$ python -V
Python 3.8.1

$ pip install sip==
Collecting sip==
  ERROR: Could not find a version that satisfies the requirement sip== (from versions: 5.0.0, 5.0.1, 5.1.0, 5.1.1)
```

Solution: the current version pyqt5==5.14.1 does not seem to have said bug anymore, and is compatible with py3.8, thus remove the version constraint.