### PR TITLE
Added support for temporal data to datlogs

### DIFF
--- a/src/rdplot/SimulationDataItemClasses/DatLogs.py
+++ b/src/rdplot/SimulationDataItemClasses/DatLogs.py
@@ -170,10 +170,18 @@ class XMLDatLog(AbstractDatLog):
         :return: tuple of labels: (x-axis label, y-axis label)
         """
         sim_data = self.sim_data
-        unit_rate = sim_data['Rate']['Unit']
-        if 'Unit' in sim_data[keys[-1]]:
-            label = (unit_rate, sim_data[keys[-1]]['Unit'])
-        else:
-            label = ('dummy', 'dummy')
 
-        return label
+        if keys[0] == 'Summary':
+            unit_rate = sim_data['Rate']['Unit']
+            label_x = unit_rate
+        elif keys[0] == 'Temporal':
+            label_x = 'Frame'
+        else:
+            label_x = 'dummy'
+
+        if 'Unit' in sim_data[keys[-1]]:
+            label_y = sim_data[keys[-1]]['Unit']
+        else:
+            label_y = 'dummy'
+
+        return (label_x, label_y)

--- a/src/rdplot/model.py
+++ b/src/rdplot/model.py
@@ -1040,7 +1040,8 @@ class BdTableModel(QAbstractTableModel):
         self._data = np.zeros((len(seq_set) + 1, len(config_set)))
         allowed_units = [("kbps","dB"),("kbps","s"),("kbps","VMAFScore")]
         if all(collection.label in allowed_units for collection in plot_data_collection):
-            self.update_table(bd_option, interp_option, 0, bd_plot)
+            if all('Summary'  in collection.path for collection in plot_data_collection):
+                self.update_table(bd_option, interp_option, 0, bd_plot)
         else:
             self.beginResetModel()
             self.reset_model()

--- a/src/rdplot/model.py
+++ b/src/rdplot/model.py
@@ -1040,8 +1040,7 @@ class BdTableModel(QAbstractTableModel):
         self._data = np.zeros((len(seq_set) + 1, len(config_set)))
         allowed_units = [("kbps","dB"),("kbps","s"),("kbps","VMAFScore")]
         if all(collection.label in allowed_units for collection in plot_data_collection):
-            if all('Summary'  in collection.path for collection in plot_data_collection):
-                self.update_table(bd_option, interp_option, 0, bd_plot)
+            self.update_table(bd_option, interp_option, 0, bd_plot)
         else:
             self.beginResetModel()
             self.reset_model()


### PR DESCRIPTION
This adds temporal data to datlog/xml files, similar as for the other parsers.

Here is a example dat log file with bogus data: 
[RaceHorses_832x480_QP22.zip](https://github.com/IENT/RDPlot/files/6680647/RaceHorses_832x480_QP22.zip)
